### PR TITLE
Feature: Emitting channel-event, when locale changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,14 +105,14 @@ export const parameters = {
 };
 ```
 
-When the locale has been changed, an event is emitted on the addons-channel.
+When the locale has been changed, an `event is emitted on the addons-channel`.
 
-You can subscribe to this event in your preview.js, to configure global environment settings yourself, related to your i18n-config.
+You can `subscribe to this event in your preview.js`, to configure global environment settings yourself, related to your i18n-config.
 
-The event is emmited with the selected locale as a parameter.
+The event is emmited with the `selected locale as a parameter`.
 
 Your implementation could look like this:
-````javascript
+```javascript
 import {addon} from '@storybook/addons'
 
 addons.getChannel().on('LOCALE_CHANGED', (newLocale) => {

--- a/README.md
+++ b/README.md
@@ -105,4 +105,20 @@ export const parameters = {
 };
 ```
 
+When the locale has been changed, an event is emitted on the addons-channel.
+
+You can subscribe to this event in your preview.js, to configure global environment settings yourself, related to your i18n-config.
+
+The event is emmited with the selected locale as a parameter.
+
+Your implementation could look like this:
+````javascript
+import {addon} from '@storybook/addons'
+
+addons.getChannel().on('LOCALE_CHANGED', (newLocale) => {
+   changeMyI18nConfig(newLocale)
+});
+```
+
+
 Addons should instruct them to use whichever format your i18n implementation expects.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "storybook-i18n",
+  "name": "storybook-i18n-with-emits",
   "version": "1.1.2",
   "description": "Tool to set the locale in Storybook for i18n",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "storybook-i18n-with-emits",
+  "name": "storybook-i18n",
   "version": "1.1.2",
   "description": "Tool to set the locale in Storybook for i18n",
   "keywords": [

--- a/src/Tool.tsx
+++ b/src/Tool.tsx
@@ -66,7 +66,7 @@ const Tool = () => {
                     links={getLocales(locales, locale, (selected) => {
                         if (selected !== locale) {
                             updateGlobals({locale: selected});
-                            addons.getChannel().emit('CHANGED_LOCALE', selected)
+                            addons.getChannel().emit('LOCALE_CHANGED', selected)
                         }
                         onHide();
                     })}

--- a/src/Tool.tsx
+++ b/src/Tool.tsx
@@ -6,6 +6,7 @@ import {
     TooltipLinkList,
 } from '@storybook/components';
 import {useGlobals} from '@storybook/api';
+import {addons} from '@storybook/addons'
 
 export interface Link {
     id: string;
@@ -65,6 +66,7 @@ const Tool = () => {
                     links={getLocales(locales, locale, (selected) => {
                         if (selected !== locale) {
                             updateGlobals({locale: selected});
+                            addons.getChannel().emit('CHANGED_LOCALE', selected)
                         }
                         onHide();
                     })}


### PR DESCRIPTION
The i18n-addon now **emits an channel-event, when the locale in the drop-down changes**.

The **README.md documents this feature** in the END-USERS section.

closes #10  