### PR TITLE
Do not use default `@storybook/addons` import.

### DIFF
--- a/src/preset/manager.tsx
+++ b/src/preset/manager.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import addons, {types} from '@storybook/addons';
+import {addons, types} from '@storybook/addons';
 import {ADDON_ID, TOOL_ID} from '../constants';
 import Tool from '../Tool';
 


### PR DESCRIPTION
Storybook 7 no longer allows the default import.  This brings the import in `src/preset/manager.tsx` in line with `src/Tool.tsx`.